### PR TITLE
Fix a bug in save path of files

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -10,7 +10,8 @@ from website.random_primary import RandomPrimaryIdModel
 
 def image_path(instance, filename, size):
     print(instance.id)
-    return '{0}/{1}{2}.jpg'.format(instance.gl.path, instance.id, size)
+    return os.path.abspath('{0}/{1}{2}.jpg'.format(instance.gl.path,
+        instance.id, size))
 
 def image_large_path(instance, filename):
     return image_path(instance, filename, '-large')


### PR DESCRIPTION
Before this commit, `polaroid` saved new images in
`{settings.MEDIA_ROOT}/{settings.MEDIA_ROOT}/{gid}/` instead of
`{settings.MEDIA_ROOT}/{gid}/`.